### PR TITLE
Handle quoted args

### DIFF
--- a/cmssw-env
+++ b/cmssw-env
@@ -89,4 +89,4 @@ if [ -e $UNPACKED_IMAGE ] ; then
   done
   export SINGULARITY_BINDPATH=$(echo ${VALID_MOUNT_POINTS} | sed 's|^,||')
 fi
-singularity -s exec ${SINGULARITY_OPTS} $UNPACKED_IMAGE sh -c "$CMD_TO_RUN"
+singularity -s exec ${SINGULARITY_OPTS} $UNPACKED_IMAGE "$CMD_TO_RUN"

--- a/cmssw-env
+++ b/cmssw-env
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 SINGULARITY_OPTS=
 BASE_SCRIPT="cmssw-env"
-CMD_TO_RUN="/bin/bash"
+CMD_TO_RUN=("/bin/bash")
 CMS_IMAGE=$(basename $0)
 THISDIR=$(dirname $0)
 while [ "$#" != 0 ]; do
@@ -24,7 +24,7 @@ while [ "$#" != 0 ]; do
       ;;
     --command-to-run|--)
       shift
-      CMD_TO_RUN="$@"
+      CMD_TO_RUN=("$@")
       break
       ;;
     *)
@@ -48,7 +48,7 @@ for dir in /etc/tnsnames.ora /eos /build /data ; do
 done
 OLD_CMSOS=$(echo ${SCRAM_ARCH} | cut -d_ -f1,2)
 if [ -e ${THISDIR}/../cmsset_default.sh ] ; then
-  CMD_TO_RUN="[ \"${OLD_CMSOS}\" != \"\$(${THISDIR}/cmsos)\" ] && export SCRAM_ARCH=""; source ${THISDIR}/../cmsset_default.sh; ${CMD_TO_RUN}"
+  CMD_TO_RUN=("[ \"${OLD_CMSOS}\" != \"\$(${THISDIR}/cmsos)\" ] && export SCRAM_ARCH=""; source ${THISDIR}/../cmsset_default.sh;" "${CMD_TO_RUN}")
 fi
 
 if [ "X${UNPACKED_IMAGE}" = "X" ] ;then
@@ -89,4 +89,4 @@ if [ -e $UNPACKED_IMAGE ] ; then
   done
   export SINGULARITY_BINDPATH=$(echo ${VALID_MOUNT_POINTS} | sed 's|^,||')
 fi
-singularity -s exec ${SINGULARITY_OPTS} $UNPACKED_IMAGE "$CMD_TO_RUN"
+singularity -s exec ${SINGULARITY_OPTS} $UNPACKED_IMAGE "${CMD_TO_RUN[@]}"


### PR DESCRIPTION
In order to assign `$@` to another variable while preserving quoted arguments, it's necessary to assign it as an array. (This comes from https://stackoverflow.com/questions/3811345/how-to-pass-all-arguments-passed-to-my-bash-script-to-a-function-of-mine; I did not figure it out myself...)

Here's the test, which can be run to show how the current version gives the wrong answer (4). The version in this PR gives the right answer (3).
```bash
cat << 'EOF' > testArgs.sh
#!/bin/bash
ARGS=("$@")
echo ${#ARGS[@]}
EOF
chmod +x testArgs.sh
./testArgs.sh 1 "2 3" 4
cmssw-env --cmsos cc6 -B $PWD --pwd $PWD -- ./testArgs.sh 1 "2 3" 4
```

I also removed the `sh -c` call, which seemed superfluous; if it's not, let me know and I'll put it back.