### PR TITLE
fix handling of multiple commands

### DIFF
--- a/cmssw-env
+++ b/cmssw-env
@@ -48,7 +48,9 @@ for dir in /etc/tnsnames.ora /eos /build /data ; do
 done
 OLD_CMSOS=$(echo ${SCRAM_ARCH} | cut -d_ -f1,2)
 if [ -e ${THISDIR}/../cmsset_default.sh ] ; then
-  CMD_TO_RUN=("[ \"${OLD_CMSOS}\" != \"\$(${THISDIR}/cmsos)\" ] && export SCRAM_ARCH=""; source ${THISDIR}/../cmsset_default.sh;" "${CMD_TO_RUN}")
+  # necessary to preserve quotes/grouping in original CMD_TO_RUN when running multiple commands through sh -c
+  printf -v CMD_STR '%q ' "${CMD_TO_RUN[@]}"
+  CMD_TO_RUN=("[ \"${OLD_CMSOS}\" != \"\$(${THISDIR}/cmsos)\" ] && export SCRAM_ARCH=""; source ${THISDIR}/../cmsset_default.sh; ${CMD_STR}")
 fi
 
 if [ "X${UNPACKED_IMAGE}" = "X" ] ;then
@@ -89,4 +91,4 @@ if [ -e $UNPACKED_IMAGE ] ; then
   done
   export SINGULARITY_BINDPATH=$(echo ${VALID_MOUNT_POINTS} | sed 's|^,||')
 fi
-singularity -s exec ${SINGULARITY_OPTS} $UNPACKED_IMAGE "${CMD_TO_RUN[@]}"
+singularity -s exec ${SINGULARITY_OPTS} $UNPACKED_IMAGE sh -c "${CMD_TO_RUN[@]}"


### PR DESCRIPTION
#3 introduced a bug, because: https://github.com/cms-sw/cmssw-osenv/blob/65ac146792e6d4b7bdd8741f157708344a8a6505/cmssw-env#L50-L52
is not activated when testing the script locally, but is activated when the script is on cvmfs.

The `sh -c` construct removed in 311508994dc7da26b783a83645b08139b894327e is necessary to handle these multiple commands (the first argument in the command passed to `singularity exec` has to be an executable, not a builtin). However, restoring this still doesn't fix the problem, because `"${CMD_TO_RUN[@]}"` preserves the quoting of the individual array elements; `sh -c` only interprets the first array element as the command, and the rest is dropped. (This preservation of quoting was intentional in #3, but it doesn't do what we want in this case.)

Using `printf` to generate a properly quoted string is a bit inelegant, but it's the only method (among many arcane bash quoting techniques) that actually works reliably.

To test this in a cvmfs-like setup, I did the following:
```
git clone git@github.com:kpedro88/cmssw-osenv -b quoted-args-2
cd cmssw-osenv
ln -s /cvmfs/cms.cern.ch/cmsset_default.sh ../
ln -s /cvmfs/cms.cern.ch/common/cmsos .
./cmssw-env --cmsos cc6 -B $(readlink -f $PWD/..) --pwd $PWD -- echo "hello world"
```
(and also reran the test from #3).

@smuzaffar should we make a unit test file for this script (based on the above), to catch bugs like this in the future?