### PR TITLE
Fix multi-command handling and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# symlinks created by tests/run.sh
+tests/cmssw-env
+/cmsset_default.sh
+tests/cmsos

--- a/cmssw-env
+++ b/cmssw-env
@@ -18,8 +18,9 @@ while [ "$#" != 0 ]; do
     -h|--help)
       HELP_ARG=""
       if [ "${CMS_IMAGE}" = "${BASE_SCRIPT}" ] ; then HELP_ARG="[--cmsos <image>] "; fi
-      echo "Usage: $0 [-h|--help] ${HELP_ARG}[extra-options] [--ignore-mount <dir1[,dir2[,...]]>] [--command-to-run|-- <command to run>]"
+      echo "Usage: $0 [-h|--help] ${HELP_ARG}[extra-options] [--ignore-mount <dir1[,dir2[,...]]>] [--command-to-run|-- <command(s)>]"
       echo "Environment variable UNPACKED_IMAGE can be set to point to either valid docker/singularity image or unpacked image path"
+      echo "If <command> includes multiple commands separated by ; or &&, or other high-precedence shell operators like >, it must be quoted"
       exit 0
       ;;
     --ignore-mount) IGNORE_MOUNTS=$(echo $2 | tr ',' ' '); shift; shift ;;

--- a/cmssw-env
+++ b/cmssw-env
@@ -56,10 +56,12 @@ for dir in /etc/tnsnames.ora /etc/pki/ca-trust /eos /build /data /afs /pool $(/b
   [ ! -e $dir ] || MOUNT_POINTS="${MOUNT_POINTS},${dir}"
 done
 OLD_CMSOS=$(echo ${SCRAM_ARCH} | cut -d_ -f1,2)
+# necessary to preserve quotes/grouping in original CMD_TO_RUN when running multiple commands through sh -c
+printf -v CMD_STR '%q ' "${CMD_TO_RUN[@]}"
 if [ -e ${THISDIR}/../cmsset_default.sh ] ; then
-  # necessary to preserve quotes/grouping in original CMD_TO_RUN when running multiple commands through sh -c
-  printf -v CMD_STR '%q ' "${CMD_TO_RUN[@]}"
   CMD_TO_RUN=("[ \"${OLD_CMSOS}\" != \"\$(${THISDIR}/cmsos)\" ] && export SCRAM_ARCH=""; source ${THISDIR}/../cmsset_default.sh >/dev/null 2>&1; ${CMD_STR}")
+else
+  CMD_TO_RUN=("${CMD_STR}")
 fi
 
 if [ "X${UNPACKED_IMAGE}" = "X" ] ;then

--- a/cmssw-env
+++ b/cmssw-env
@@ -58,10 +58,13 @@ done
 OLD_CMSOS=$(echo ${SCRAM_ARCH} | cut -d_ -f1,2)
 # necessary to preserve quotes/grouping in original CMD_TO_RUN when running multiple commands through sh -c
 printf -v CMD_STR '%q ' "${CMD_TO_RUN[@]}"
+# necessary to expand multi-command input given as quoted string
+CMD_PREF=
+if [ "${#CMD_TO_RUN[@]}" -eq 1 ]; then CMD_PREF="eval "; fi
 if [ -e ${THISDIR}/../cmsset_default.sh ] ; then
-  CMD_TO_RUN=("[ \"${OLD_CMSOS}\" != \"\$(${THISDIR}/cmsos)\" ] && export SCRAM_ARCH=""; source ${THISDIR}/../cmsset_default.sh >/dev/null 2>&1; ${CMD_STR}")
+  CMD_TO_RUN=("[ \"${OLD_CMSOS}\" != \"\$(${THISDIR}/cmsos)\" ] && export SCRAM_ARCH=""; source ${THISDIR}/../cmsset_default.sh >/dev/null 2>&1; ${CMD_PREF}${CMD_STR}")
 else
-  CMD_TO_RUN=("${CMD_STR}")
+  CMD_TO_RUN=("${CMD_PREF}${CMD_STR}")
 fi
 
 if [ "X${UNPACKED_IMAGE}" = "X" ] ;then

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Pass in name and status
+function die { echo $1: status $2 ;  exit $2; }
+
+function tests() {
+	# test argument quoting
+	TEST=1
+	EXPECTED="hello world"
+	RESULT=$(./cmssw-env --cmsos cc7 -B $PWD --pwd $PWD -- echo "$EXPECTED")
+	if [ "$RESULT" != "$EXPECTED" ]; then die "Test $TEST: wrong output $RESULT (should be $EXPECTED)" 1; fi
+
+	# test argument quoting with script
+	TEST=2
+	EXPECTED=3
+	RESULT=$(./cmssw-env --cmsos cc7 -B $PWD --pwd $PWD -- ./testArgs.sh 1 "2 3" 4)
+	if [ "$RESULT" -ne "$EXPECTED" ]; then die "Test $TEST: incorrect number of arguments $RESULT (should be $EXPECTED)" 1; fi
+}
+
+# common setup
+ln -sf ../cmssw-env .
+
+# cvmfs-like setup
+ln -sf /cvmfs/cms.cern.ch/cmsset_default.sh ../
+ln -sf /cvmfs/cms.cern.ch/common/cmsos .
+
+echo "Testing with cvmfs-like setup"
+tests
+
+# standalone setup
+rm ../cmsset_default.sh
+rm cmsos
+
+echo "Testing with standalone setup"
+tests

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -4,6 +4,12 @@
 function die { echo $1: status $2 ;  exit $2; }
 
 function tests() {
+	# test single command
+	TEST=0
+	EXPECTED=""
+	RESULT=$(./cmssw-env --cmsos cc7 -B $PWD --pwd $PWD -- echo)
+	if [ "$RESULT" != "$EXPECTED" ]; then die "Test $TEST: wrong output $RESULT (should be $EXPECTED)" 1; fi
+
 	# test argument quoting
 	TEST=1
 	EXPECTED="hello world"
@@ -15,6 +21,17 @@ function tests() {
 	EXPECTED=3
 	RESULT=$(./cmssw-env --cmsos cc7 -B $PWD --pwd $PWD -- ./testArgs.sh 1 "2 3" 4)
 	if [ "$RESULT" -ne "$EXPECTED" ]; then die "Test $TEST: incorrect number of arguments $RESULT (should be $EXPECTED)" 1; fi
+
+	# test argument quoting with script, fully quoted
+	TEST=2b
+	RESULT=$(./cmssw-env --cmsos cc7 -B $PWD --pwd $PWD -- './testArgs.sh 1 "2 3" 4')
+	if [ "$RESULT" -ne "$EXPECTED" ]; then die "Test $TEST: incorrect number of arguments $RESULT (should be $EXPECTED)" 1; fi
+
+	# test multi-command case
+	TEST=3
+	EXPECTED=$(echo foo; echo bar)
+	RESULT=$(./cmssw-env --cmsos cc7 -B $PWD --pwd $PWD -- "echo foo; echo bar")
+	if [ "$RESULT" != "$EXPECTED" ]; then die "Test $TEST: wrong output $RESULT (should be $EXPECTED)" 1; fi
 }
 
 # common setup

--- a/tests/testArgs.sh
+++ b/tests/testArgs.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+ARGS=("$@")
+echo ${#ARGS[@]}


### PR DESCRIPTION
Addresses issue reported in https://cms-talk.web.cern.ch/t/issue-with-command-to-run-in-cmssw-cc7-singularity/32815/, while still allowing the use of arguments not surrounded by quotes in the single-command, multi-argument case.

Adds tests for various behavior, including the tests used in #3 and #4. Also fixes the "standalone" (non-cvmfs) case, which had been inadvertently left broken in #4.