### PR TITLE
avoid using scram v3 in el6 env

### DIFF
--- a/cmssw-env
+++ b/cmssw-env
@@ -47,6 +47,15 @@ while [ "$#" != 0 ]; do
   esac
 done
 
+if [ "${CMS_IMAGE}" = "cmssw-el6" ] ; then
+  #Always use SCRAM V2 for el6
+  #Avoid accidental usage of scram V3 if scram command ran from a project area which uses scram v3
+  export SCRAM_VERSION=V2_99_99
+  export SCRAM_NO_VERSION_SPAWN=true
+else
+  export SCRAM_NO_VERSION_SPAWN=false
+fi
+
 if [ -d /cvmfs ] ; then
   cvmfs_repos="cms cms-ib grid unpacked"
   case "$(hostname -d)" in cern.ch|cms) cvmfs_repos="${cvmfs_repos} projects" ;; esac


### PR DESCRIPTION
If `cmssw-el6` is started from a cmssw area which uses SCRAM V3 then default scram used within el6 env is also V3 which breaks scram as `python3` needed by scram V3 is not available in el6. This change forces usage of SCRAM V2 in el6. 

This change should be safe as we do not have any cmssw release which uses scram v3 for el6.