### PR TITLE
restore bindpath print in --show-command

### DIFF
--- a/cmssw-env
+++ b/cmssw-env
@@ -150,7 +150,7 @@ if [ -e $UNPACKED_IMAGE ] ; then
     $mount_path && VALID_MOUNT_POINTS="${VALID_MOUNT_POINTS},${dir}"
   done
   VALID_MOUNT_POINTS=$(echo ${VALID_MOUNT_POINTS} | sed 's|^,||')
-  export ${BINDPATH_ENV}=${VALID_MOUNT_POINTS}
+  ${SHOW_COMMAND} ; export ${BINDPATH_ENV}=${VALID_MOUNT_POINTS}
 fi
 
 #See https://github.com/cms-sw/cmssw-osenv/issues/17


### PR DESCRIPTION
https://github.com/cms-sw/cmssw-osenv/commit/2498b0520134e240960188143a2c77f03994dce0 changed how `--show-command` works internally. It is supposed to show the value of the `APPTAINER_BINDPATH` variable as well as the apptainer command (https://github.com/cms-sw/cmssw-osenv/pull/15#issuecomment-2066869712, https://github.com/cms-sw/cmssw-osenv/pull/15/commits/4fe606d7cefb2cd4c356bfeb655974095a82fa05). This PR restores the desired behavior.